### PR TITLE
Log failures to find open FDs as debug logs

### DIFF
--- a/sdk/src/system/Process.cpp
+++ b/sdk/src/system/Process.cpp
@@ -1138,6 +1138,14 @@ Error AbstractChildProcess::run()
 
    // Now fork the process.
    error = posix::posixCall<pid_t>(::fork, ERROR_LOCATION, &m_baseImpl->Pid);
+   if (error)
+   {
+      closePipe(fds.Input, ERROR_LOCATION);
+      closePipe(fds.Output, ERROR_LOCATION);
+      closePipe(fds.Error, ERROR_LOCATION);
+      closePipe(fds.CloseFd, ERROR_LOCATION);
+      return error;
+   }
 
    // If this is the child process, execute the requested process.
    if (m_baseImpl->Pid == 0)
@@ -1162,9 +1170,9 @@ Error AbstractChildProcess::run()
 
       // Send the list of the child's open pipes to it.
       error = sendFileDescriptors(fds.CloseFd[s_writePipe], m_baseImpl->Pid);
+      if (error)
+         logging::logError(error);
       closePipe(fds.CloseFd[s_writePipe], ERROR_LOCATION);
-
-      return error;
    }
 
    return Success();


### PR DESCRIPTION
This fixes a bug where we would log error messages whenever we couldn't get the list of open FDS. 

It also adjusts some process launch behaviours in the SDK to match behaviours in the IDE.