### PR TITLE
RSP Rebranding

### DIFF
--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -33,7 +33,7 @@ not needed unless you wish to regenerate the Doxygen documentation.
 
 ## install-rsandbox.sh
 
-This script installs the `rsandbox` executable from the RStudio Server Pro session components. It is
+This script installs the `rsandbox` executable from the RStudio Workbench session components. It is
 required by the RStudio Launcher Plugin SDK to run child processes. Usage: 
 `./install-rsandbox.sh <platform>`. Valid platforms are:
 * `centos8`

--- a/docs/bookdown/developer-guide/01-prereqs.Rmd
+++ b/docs/bookdown/developer-guide/01-prereqs.Rmd
@@ -2,7 +2,7 @@
 
 ## Platform Support {#plat-support}
 
-Plugins developed with the SDK require the RStudio Launcher to work. The SDK is currently compatible with the version of the RStudio Launcher that is shipped with RStudio Workbench v1.4.1. As such, the SDK will be supported on all of the platforms supported by RStudio Workbench v1.4.1, which can be found on the [Requirements for RStudio Workbench page](https://docs.rstudio.com/rsp/requirements/).
+Plugins developed with the SDK require the RStudio Launcher to work. The SDK is currently compatible with the version of the RStudio Launcher that is shipped with RStudio Workbench v1.4. As such, the SDK will be supported on all of the platforms supported by RStudio Workbench v1.4, which can be found on the [Requirements for RStudio Workbench page](https://docs.rstudio.com/rsp/requirements/).
 
 ## Build Dependencies {#builddep}
 
@@ -21,7 +21,7 @@ Boost     1.70.0             https://www.boost.org/
 
 ## RStudio Workbench {#rsw}
 
-This version of the RStudio Launcher Plugin SDK is compatible with RStudio Workbench version 1.4.1, or greater. To properly test the integration between a Launcher Plugin and RStudio Workbench, an RStudio Workbench license, with the launcher feature enabled, is required. To acquire a license, please contact sales@rstudio.com.
+This version of the RStudio Launcher Plugin SDK is compatible with RStudio Workbench version 1.4, or greater. To properly test the integration between a Launcher Plugin and RStudio Workbench, an RStudio Workbench license, with the launcher feature enabled, is required. To acquire a license, please contact sales@rstudio.com.
 
 ## Job Scheduling System {#jss}
 

--- a/docs/bookdown/developer-guide/01-prereqs.Rmd
+++ b/docs/bookdown/developer-guide/01-prereqs.Rmd
@@ -2,7 +2,7 @@
 
 ## Platform Support {#plat-support}
 
-Plugins developed with the SDK require the RStudio Launcher to work. The SDK is currently compatible with the version of the RStudio Launcher that is shipped with RStudio Server Pro v1.4. As such, the SDK will be supported on all of the platforms supported by RStudio Server Pro v1.4, which can be found on the [Requirements for RStudio Server Pro page](https://docs.rstudio.com/rsp/requirements/).
+Plugins developed with the SDK require the RStudio Launcher to work. The SDK is currently compatible with the version of the RStudio Launcher that is shipped with RStudio Workbench v1.4.1. As such, the SDK will be supported on all of the platforms supported by RStudio Workbench v1.4.1, which can be found on the [Requirements for RStudio Workbench page](https://docs.rstudio.com/rsp/requirements/).
 
 ## Build Dependencies {#builddep}
 
@@ -19,9 +19,9 @@ cmake     3.15.5             https://cmake.org/
 Boost     1.70.0             https://www.boost.org/
 
 
-## RStudio Server Pro {#rsp}
+## RStudio Workbench {#rsw}
 
-This version of the RStudio Launcher Plugin SDK is compatible with RStudio Server Pro version 1.4, or greater. To properly test the integration between a Launcher Plugin and RStudio Server Pro, an RStudio Server Pro license, with the launcher feature enabled, is required. To acquire a license, please contact sales@rstudio.com.
+This version of the RStudio Launcher Plugin SDK is compatible with RStudio Workbench version 1.4.1, or greater. To properly test the integration between a Launcher Plugin and RStudio Workbench, an RStudio Workbench license, with the launcher feature enabled, is required. To acquire a license, please contact sales@rstudio.com.
 
 ## Job Scheduling System {#jss}
 

--- a/docs/bookdown/developer-guide/02-launcher.Rmd
+++ b/docs/bookdown/developer-guide/02-launcher.Rmd
@@ -1,6 +1,6 @@
 # The RStudio Launcher {#launcher}
 
-The purpose of the RStudio Launcher is to provide a generic interface to integrate job scheduling systems with RStudio Server Pro and other RStudio products. The Launcher itself is not specific to R processes, and can launch arbitrary work through any job scheduling system for which a Plugin  exists. This section will describe the way that RStudio products may integrate with the Launcher, the way the Launcher communicates with and manages Plugins, and network architecture requirements.
+The purpose of the RStudio Launcher is to provide a generic interface to integrate job scheduling systems with RStudio Workbench and other RStudio products. The Launcher itself is not specific to R processes, and can launch arbitrary work through any job scheduling system for which a Plugin  exists. This section will describe the way that RStudio products may integrate with the Launcher, the way the Launcher communicates with and manages Plugins, and network architecture requirements.
 
 ## Public Interface {#launcher-pub}
 
@@ -18,7 +18,7 @@ Receiving requests, formatting and sending responses, and listening for signals 
 
 ## Network Architecture Requirements {#net-arch}
 
-As mentioned in section \@ref(launcher-pub), it is not necessary for the Launcher and the RStudio product which will make use of it to be running on the same machine. The RStudio product which will use the Launcher needs to be able to communicate with the launcher over HTTP or HTTPS on the configured port. The default Launcher port is `5559`, but it can be modified in `launcher.rstudio.conf`. In figure \@ref(fig:simple-net), a very simple network architecture is shown in which RStudio Server Pro is running on Host A and the Launcher and its Plugins are running on Host B. The Plugins must also be able to reach and communicate with their respective job scheduling systems.
+As mentioned in section \@ref(launcher-pub), it is not necessary for the Launcher and the RStudio product which will make use of it to be running on the same machine. The RStudio product which will use the Launcher needs to be able to communicate with the launcher over HTTP or HTTPS on the configured port. The default Launcher port is `5559`, but it can be modified in `launcher.rstudio.conf`. In figure \@ref(fig:simple-net), a very simple network architecture is shown in which RStudio Workbench is running on Host A and the Launcher and its Plugins are running on Host B. The Plugins must also be able to reach and communicate with their respective job scheduling systems.
 
 ```{r simple-net, echo=FALSE, eval=TRUE, fig.cap="Simple Launcher Network Architecture", fig.align="center"}
 knitr::include_graphics("images/simple-two-machine.png")
@@ -32,20 +32,20 @@ knitr::include_graphics("images/load-balanced.png")
 
 In order to work correctly with a load balanced architecture, the Plugin implementation must be able to return the same output from any Plugin which is part of the Launcher cluster. As each API call is described in detail in the following sections, requirements for an implementation of that API call which supports load balancing will be discussed.
 
-### RStudio Server Pro Integration {#rsp-int}
+### RStudio Workbench Integration {#rsw-int}
 
-When integrating the Launcher with RStudio Server Pro, there are two additional cases which must be considered when configuring the network: using Launcher Sessions, and using Launcher Jobs. Regardless of whether the Launcher is load balanced the network requirements stay the same, so the diagrams in this section will be based on the architecture describned in figure \@ref(fig:simple-net), but may be applied to the architecture described in figure \@ref(fig:load-balanced-net).
+When integrating the Launcher with RStudio Workbench, there are two additional cases which must be considered when configuring the network: using Launcher Sessions, and using Launcher Jobs. Regardless of whether the Launcher is load balanced the network requirements stay the same, so the diagrams in this section will be based on the architecture describned in figure \@ref(fig:simple-net), but may be applied to the architecture described in figure \@ref(fig:load-balanced-net).
 
-When using Launcher Sessions, the RStudio Server Pro process must be able to communicate with the R, Jupyter, or other session over TCP on an arbitrary port.
+When using Launcher Sessions, the RStudio Workbench process(es) must be able to communicate with the R, Jupyter, or other session over TCP on an arbitrary port.
 
 ```{r session-net, echo=FALSE, eval=TRUE, fig.cap="Launcher Sessions", fig.align="center"}
 knitr::include_graphics("images/simple-two-machine-sessions.png")
 ```
 
-When using Launcher Jobs without Launcher Sessions, there are no special network considerations. However, when using Launcher Jobs with Launcher Sessions the R sessions must be able to communicate with RStudio Server Pro over HTTP(S), in the same way as an RStudio IDE user would.
+When using Launcher Jobs without Launcher Sessions, there are no special network considerations. However, when using Launcher Jobs with Launcher Sessions the R sessions must be able to communicate with RStudio Workbench over HTTP(S), in the same way as an RStudio IDE user would.
 
 ```{r session-job-net, echo=FALSE, eval=TRUE, fig.cap="Launcher Jobs with Launcher Sessions", fig.align="center"}
 knitr::include_graphics("images/sessions-and-jobs.png")
 ```
 
-For more details about configuring the RStudio Server and the Launcher, see the [RStudio Server Pro Administration Guide](https://docs.rstudio.com/ide/server-pro/).
+For more details about configuring RStudio Workbench and the Launcher, see the [RStudio Workbench Administration Guide](https://docs.rstudio.com/ide/server-pro/).

--- a/docs/bookdown/developer-guide/05-advanced-features.Rmd
+++ b/docs/bookdown/developer-guide/05-advanced-features.Rmd
@@ -454,7 +454,7 @@ Error MarsJobSource::initialize()
 
 ## Custom Job Source Configuration {#job-config-feature}
 
-> Important: This feature is not exposed through the RStudio Server Pro job launching UI. The use of this feature will require a feature request to the RStudio IDE project. This feature should only be used when there are no other alternatives.
+> Important: This feature is not exposed through the RStudio Workbench job launching UI. The use of this feature will require a feature request to the RStudio IDE project. This feature should only be used when there are no other alternatives.
 
 The [Cluster Info Response](#cluster-info) is used to report the configuration and capabilities of the Plugin. The RStudio Launcher Plugin SDK QuickStart Guide describes how the Plugin Developer may declare support for various types of resource limits, containers, custom job placement constraints, and job queues. In the event that there is some job configuration setting that is not covered by one of those built-in job settings, the Job Config feature may used.
 
@@ -677,7 +677,7 @@ Error MarsJobStatusWatcher::getJobDetails(const std::string& in_jobId, api::JobP
 
 ### Other Methods {#status-updates-other}
 
-It is possible that neither streaming nor polling are the best solution for keeping job statuses up to date. The use of an `AbstractJobStatusWatcher` is completely optional, and the Plugin developer may choose to implement this feature in any way that best suits the Job Scheduling System. For example, the provided sample Local Plugin does not use an `AbstractJobStatusWatcher`. Jobs are launched on the local system by forking a new processes and running the requested command in that process. The Local Plugin receives notifications when the child process writes to standard out, standard error, or exits. When the process exits, the Job state is transitioned from `Job::State::RUNNING` to `Job::State::FINISHED`. The Local Plugin also keeps track of when the process should transition from `Job::State::PENDING` to `Job::State::RUNNING` by checking whether the executable name has changed from `rsandbox` (a utility for launching processes in an isolated environment provided with the RStudio Server Pro installation) to the name of the actual executable for the Job.
+It is possible that neither streaming nor polling are the best solution for keeping job statuses up to date. The use of an `AbstractJobStatusWatcher` is completely optional, and the Plugin developer may choose to implement this feature in any way that best suits the Job Scheduling System. For example, the provided sample Local Plugin does not use an `AbstractJobStatusWatcher`. Jobs are launched on the local system by forking a new processes and running the requested command in that process. The Local Plugin receives notifications when the child process writes to standard out, standard error, or exits. When the process exits, the Job state is transitioned from `Job::State::RUNNING` to `Job::State::FINISHED`. The Local Plugin also keeps track of when the process should transition from `Job::State::PENDING` to `Job::State::RUNNING` by checking whether the executable name has changed from `rsandbox` (a utility for launching processes in an isolated environment provided with the RStudio Workbench installation) to the name of the actual executable for the Job.
 
 ## Customizing the Job Repository {#job-repo}
 

--- a/docs/bookdown/quickstart-guide/01-introduction.Rmd
+++ b/docs/bookdown/quickstart-guide/01-introduction.Rmd
@@ -5,13 +5,13 @@ The goal of an RStudio Launcher Plugin is to implement each RStudio Launcher API
 
 Figure \@ref(fig:rl-arch) depicts the architecture of the RStudio Launcher, using three existing RStudio Launcher Plugins as examples. The following communication will occur if a user creates a new R session in the Kubernetes cluster:
 
-1. RStudio Server Pro will build the command and arguments to run the R Session.
-2. RStudio Server Pro will send a job submission request to the RStudio Launcher over HTTP, including the R Session command, arguments, the user-requested cluster, and any resource constraints set by the user.
+1. RStudio Workbench will build the command and arguments to run the R Session.
+2. RStudio Workbench will send a job submission request to the RStudio Launcher over HTTP, including the R Session command, arguments, the user-requested cluster, and any resource constraints set by the user.
 3. The RStudio Launcher will verify that a cluster matching the requested Kubernetes cluster exists.
 4. Upon finding a valid Kubernetes cluster, the RStudio Launcher will forward the request to the RStudio Kubernetes Launcher Plugin via the JSON RStudio Launcher Plugin API.
 5. The Kubernetes Plugin will create a pod with the requested resource restrictions and launch the R Session with the specified command and arguments, via the Kubernetes HTTP API.
 6. The Kubernetes Plugin will report either success or failure to the RStudio Launcher via the JSON RStudio Launcher Plugin API, based on the response from the Kubernetes HTTP API.
-7. The RStudio Launcher will forward the result to RStudio Server Pro via the RStudio Launcher HTTP API.
+7. The RStudio Launcher will forward the result to RStudio Workbench via the RStudio Launcher HTTP API.
 
 ```{r rl-arch, echo=FALSE, fig.cap="RStudio Launcher Archeticture", fig.align="center"}
 knitr::include_graphics("images/simple-launcher.png")

--- a/docs/bookdown/quickstart-guide/02-getstarted.Rmd
+++ b/docs/bookdown/quickstart-guide/02-getstarted.Rmd
@@ -4,7 +4,7 @@
 
 ### Platform Support
 
-Plugins developed with the SDK require the RStudio Launcher to work. The SDK is currently compatible with the version of the RStudio Launcher that is shipped with RStudio Workbench v1.4.1. As such, the SDK will be supported on all of the platforms supported by RStudio Workbench v1.4.1, which can be found on the [Requirements for RStudio Workbench page](https://docs.rstudio.com/rsp/requirements/).
+Plugins developed with the SDK require the RStudio Launcher to work. The SDK is currently compatible with the version of the RStudio Launcher that is shipped with RStudio Workbench v1.4. As such, the SDK will be supported on all of the platforms supported by RStudio Workbench v1.4, which can be found on the [Requirements for RStudio Workbench page](https://docs.rstudio.com/rsp/requirements/).
 
 ### Build Dependencies
 
@@ -22,7 +22,7 @@ Boost     1.70.0             https://www.boost.org/
 
 ### RStudio Workbench
 
-This version of the RStudio Launcher Plugin SDK is compatible with RStudio Workbench version 1.4.1, or greater. To properly test the integration between a Launcher Plugin and RStudio Workbench, an RStudio Workbench license, with the launcher feature enabled, is required. To acquire a license, please contact sales@rstudio.com.
+This version of the RStudio Launcher Plugin SDK is compatible with RStudio Workbench version 1.4, or greater. To properly test the integration between a Launcher Plugin and RStudio Workbench, an RStudio Workbench license, with the launcher feature enabled, is required. To acquire a license, please contact sales@rstudio.com.
 
 ### Job Scheduling System
 

--- a/docs/bookdown/quickstart-guide/02-getstarted.Rmd
+++ b/docs/bookdown/quickstart-guide/02-getstarted.Rmd
@@ -4,7 +4,7 @@
 
 ### Platform Support
 
-Plugins developed with the SDK require the RStudio Launcher to work. The SDK is currently compatible with the version of the RStudio Launcher that is shipped with RStudio Server Pro v1.4. As such, the SDK will be supported on all of the platforms supported by RStudio Server Pro v1.4, which can be found on the [Requirements for RStudio Server Pro page](https://docs.rstudio.com/rsp/requirements/).
+Plugins developed with the SDK require the RStudio Launcher to work. The SDK is currently compatible with the version of the RStudio Launcher that is shipped with RStudio Workbench v1.4.1. As such, the SDK will be supported on all of the platforms supported by RStudio Workbench v1.4.1, which can be found on the [Requirements for RStudio Workbench page](https://docs.rstudio.com/rsp/requirements/).
 
 ### Build Dependencies
 
@@ -20,9 +20,9 @@ gcc/g++   4.8                https://gcc.gnu.org/
 cmake     3.15.5             https://cmake.org/
 Boost     1.70.0             https://www.boost.org/
 
-### RStudio Server Pro
+### RStudio Workbench
 
-This version of the RStudio Launcher Plugin SDK is compatible with RStudio Server Pro version 1.4, or greater. To properly test the integration between a Launcher Plugin and RStudio Server Pro, an RStudio Server Pro license, with the launcher feature enabled, is required. To acquire a license, please contact sales@rstudio.com.
+This version of the RStudio Launcher Plugin SDK is compatible with RStudio Workbench version 1.4.1, or greater. To properly test the integration between a Launcher Plugin and RStudio Workbench, an RStudio Workbench license, with the launcher feature enabled, is required. To acquire a license, please contact sales@rstudio.com.
 
 ### Job Scheduling System
 

--- a/docs/bookdown/quickstart-guide/03-todos.Rmd
+++ b/docs/bookdown/quickstart-guide/03-todos.Rmd
@@ -704,7 +704,7 @@ QuickStartJobSource.cpp   QuickStartJobSource.cpp
 
 The `QuickStartJobStatusWatcher` doesn't actually update any Job statuses, as there is no QuickStart Job Scheduling System to pull jobs from. To reduce the amount of busy-work the QuickStart Plugin will do when run, the polling frequency of the Job Status Watcher is set to 1 minute. In reality, Job statuses should be kept much more up to date, on the order of seconds rather than minutes. 
 
-The Plugin developer may choose a fixed interval, such as 5 seconds, or allow the RStudio Server Pro administrator to decide the number of seconds using a configuration option.
+The Plugin developer may choose a fixed interval, such as 5 seconds, or allow the RStudio Workbench administrator to decide the number of seconds using a configuration option.
 
 ### Example {#todo-11-ex}
 
@@ -1076,7 +1076,7 @@ TODO Location             Impact
 ------------------------  ------------------------
 QuickStartJobSource.cpp   QuickStartJobSource.cpp
 
-Some use cases of the Launcher may require the ability to communicate with a remotely launched job. For example, when using the Launcher to run RStudio R Sessions, the RStudio Server needs to be able to communicate with the R Session over TCP. To facilitate this, the Plugin must be able to provide network information for each Job. 
+Some use cases of the Launcher may require the ability to communicate with a remotely launched job. For example, when using the Launcher to run RStudio R Sessions, RStudio Workbench needs to be able to communicate with the R Session over TCP. To facilitate this, the Plugin must be able to provide network information for each Job. 
 
 The Plugin developer should implement `IJobSource::getNetworkInfo` so that it populates the `out_networkInfo` object with the hostname and IP addresses of the host running the specified Job.
 

--- a/sdk/include/options/Options.hpp
+++ b/sdk/include/options/Options.hpp
@@ -247,9 +247,9 @@ public:
    const std::string& getPluginName() const;
 
    /**
-    * @brief Gets the path to the rsandbox executable provided by the RStudio Server Pro installation.
+    * @brief Gets the path to the rsandbox executable provided by the RStudio Workbench installation.
     *
-    * If RStudio Server Pro is installed to the default location, this value does not need to be set.
+    * If RStudio Workbench is installed to the default location, this value does not need to be set.
     *
     * @return The path to the rsandbox executable.
     */

--- a/smoke-test/README.md
+++ b/smoke-test/README.md
@@ -27,4 +27,4 @@ Caveats
 The smoke test tool does not test all required functionality for each request type. It is meant as a 
 utility to help ensure that the Plugin is behaving as expected in the basic case, and to facilitate 
 debugging requests. To ensure that the Plugin is fully functional, it should be tested against 
-RStudio Server Pro with the RStudio Launcher enabled.
+RStudio Workbench with the RStudio Launcher enabled.

--- a/tools/create-test-users.sh
+++ b/tools/create-test-users.sh
@@ -85,7 +85,7 @@ addUser()
   echo "Done."
 }
 
-# Create the RStudio Server User, if it does not already exist
+# Create the RStudio Workbench server user, if it does not already exist
 if [[ -n $1 && $1 -ne 0 ]]; then
   echo "Adding rstudio-server user..."
   sudo useradd --system "rstudio-server"


### PR DESCRIPTION
Rename all instances of RStudio Server to RStudio Workbench for rebranding.

This PR does not change any of the SVG/PNG graphics that include the `RStudio Server` name. I will need direction on how to modify these before I can fix them and include them in the pull request.

Companion PR to https://github.com/rstudio/rstudio-pro/pull/2296.