### PR TITLE
Fix build warnings due to a missing `override`

### DIFF
--- a/sdk/include/api/stream/AbstractResourceStream.hpp
+++ b/sdk/include/api/stream/AbstractResourceStream.hpp
@@ -61,7 +61,7 @@ public:
     * 
     * @return Success if resource utilization streaming was started correctly; Error otherwise.
     */
-   virtual Error initialize() = 0;
+   virtual Error initialize() override = 0;
 
    /**
     * @brief Notifies that the data stream has completed.


### PR DESCRIPTION
This silences the following warning:

    rstudio-launcher-plugin-sdk/sdk/include/api/stream/AbstractResourceStream.hpp:64:18: warning: 'initialize' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
       virtual Error initialize() = 0;
                     ^
    rstudio-launcher-plugin-sdk/sdk/include/api/stream/AbstractMultiStream.hpp:81:18: note: overridden virtual function is here
       virtual Error initialize() = 0;
