### PR TITLE
Fix builds on macOS

### DIFF
--- a/plugins/Local/CMakeLists.txt
+++ b/plugins/Local/CMakeLists.txt
@@ -22,7 +22,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(rstudio_local_plugin)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 # include files
 file(GLOB_RECURSE LOCAL_HEADER_FILES "*.h*")

--- a/plugins/Local/src/LocalMain.cpp
+++ b/plugins/Local/src/LocalMain.cpp
@@ -23,6 +23,10 @@
 #include <climits>
 #include <unistd.h>
 
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#endif
+
 #include <LocalOptions.hpp>
 #include <LocalPluginApi.hpp>
 

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -22,7 +22,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(rstudio_launcher_plugin_sdk)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 find_library(PTHREAD_LIBS pthread)
 

--- a/sdk/src/system/PosixSystem.cpp
+++ b/sdk/src/system/PosixSystem.cpp
@@ -28,7 +28,10 @@
 #include <memory.h>
 #include <netdb.h>
 #include <pwd.h>
+
+#ifdef __linux__
 #include <sys/prctl.h>
+#endif
 
 #include <Error.hpp>
 #include <system/User.hpp>
@@ -74,9 +77,11 @@ Error restorePrivilegesImpl(uid_t in_uid)
 
 Error enableCoreDumps()
 {
+#ifdef __linux__
    int res = ::prctl(PR_SET_DUMPABLE, 1);
    if (res == -1)
       return systemError(errno, ERROR_LOCATION);
+#endif
 
    return Success();
 }

--- a/sdk/src/system/Process.cpp
+++ b/sdk/src/system/Process.cpp
@@ -27,6 +27,7 @@
 #include <cstring>
 #include <dirent.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
 #include <sys/wait.h>

--- a/smoke-test/CMakeLists.txt
+++ b/smoke-test/CMakeLists.txt
@@ -22,7 +22,7 @@
 cmake_minimum_required(VERSION 3.14)
 project(rstudio_launcher_plugin_smoke_test)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 # include files
 file(GLOB_RECURSE SMOKE_TEST_HEADER_FILES "*.h*")


### PR DESCRIPTION
This fixes a few compatibility cases and allows the project to be built on macOS:

* Define `HOST_NAME_MAX` to its POSIX equivalent if not present.

* Gate calls to `ptrctl()`, which is a Linux-specific syscall.

* Include `<signal.h>`, which is the canonical header for `kill()`.

* Use C++17, which is required for our use of `weak_for_this()` when building with Clang.

macOS builds are useful for testing with the smoke-test tool; obviously the Launcher itself does not run on macOS.