### PR TITLE
Update Boost to 1.83.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,7 @@ project(rlp_sdk_all)
 
 # include globals
 include(CMakeGlobals.txt)
-
 set(CMAKE_CXX_STANDARD 11)
-
 
 string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type)
 if (NOT build_type STREQUAL "debug")
@@ -35,7 +33,7 @@ endif()
 
 # include boost
 if (NOT RLPS_BOOST_REQUESTED_VERSION)
-   set(RLPS_BOOST_REQUESTED_VERSION 1.70.0)
+   set(RLPS_BOOST_REQUESTED_VERSION 1.83.0)
 endif()
 set(Boost_NO_BOOST_CMAKE      OFF)
 set(Boost_USE_STATIC_LIBS     ON)

--- a/dependencies/install-boost.sh
+++ b/dependencies/install-boost.sh
@@ -29,7 +29,7 @@ set -e
 INSTALL_DIR=$(pwd)
 
 # Variables
-BOOST_VERSION_NUMBER="1.70.0"
+BOOST_VERSION_NUMBER="1.83.0"
 BOOST_VERSION="boost_$(echo "$BOOST_VERSION_NUMBER" | tr "." "_")"
 BOOST_TAR="$BOOST_VERSION.tar.bz2"
 BOOST_BUILD_DIR="boost-build"
@@ -65,7 +65,7 @@ then
    sudo ./bootstrap.sh
 
    # Build boost with bjam
-   sudo ./bjam                      \
+   sudo ./b2                    \
         "$BOOST_BJAM_FLAGS"         \
         variant=release             \
         cxxflags="-fPIC -std=c++11" \

--- a/dependencies/install-boost.sh
+++ b/dependencies/install-boost.sh
@@ -65,7 +65,7 @@ then
    sudo ./bootstrap.sh
 
    # Build boost with bjam
-   sudo ./bjam                    \
+   sudo ./b2                    \
         "$BOOST_BJAM_FLAGS"         \
         variant=release             \
         cxxflags="-fPIC -std=c++11" \

--- a/docker/jenkins/Dockerfile.versioning
+++ b/docker/jenkins/Dockerfile.versioning
@@ -9,7 +9,7 @@ RUN apk -v --update add \
         mailcap \
         sudo \
         && \
-    pip install --upgrade awscli s3cmd python-magic && \
+    pip3 install --upgrade awscli s3cmd python-magic && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/* && \
     mkdir -p /scripts

--- a/docker/jenkins/Dockerfile.versioning
+++ b/docker/jenkins/Dockerfile.versioning
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:latest
 RUN apk -v --update add \
         bash \
         python \
@@ -9,7 +9,7 @@ RUN apk -v --update add \
         mailcap \
         sudo \
         && \
-    pip install --upgrade awscli==0.4.1 s3cmd python-magic && \
+    pip install --upgrade awscli s3cmd python-magic && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/* && \
     mkdir -p /scripts

--- a/docker/jenkins/Dockerfile.versioning
+++ b/docker/jenkins/Dockerfile.versioning
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.20
 RUN apk -v --update add \
         bash \
         python \

--- a/docker/jenkins/Dockerfile.versioning
+++ b/docker/jenkins/Dockerfile.versioning
@@ -1,17 +1,14 @@
 FROM alpine:3.20
-RUN apk -v --update add \
+RUN apk -v --update --no-cache add \
         bash \
         python3 \
-        py-pip \
         git \
         groff \
         less \
         mailcap \
         sudo \
         && \
-    pip3 install --upgrade awscli s3cmd python-magic && \
-    apk -v --purge del py-pip && \
-    rm /var/cache/apk/* && \
+    apk add --no-cache aws-cli s3cmd py3-magic && \
     mkdir -p /scripts
 
 ARG JENKINS_GID=999

--- a/docker/jenkins/Dockerfile.versioning
+++ b/docker/jenkins/Dockerfile.versioning
@@ -1,7 +1,7 @@
 FROM alpine:3.20
 RUN apk -v --update add \
         bash \
-        python \
+        python3 \
         py-pip \
         git \
         groff \

--- a/docker/jenkins/Dockerfile.versioning
+++ b/docker/jenkins/Dockerfile.versioning
@@ -9,7 +9,7 @@ RUN apk -v --update add \
         mailcap \
         sudo \
         && \
-    pip install --upgrade awscli s3cmd python-magic && \
+    pip install --upgrade awscli==0.4.1 s3cmd python-magic && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/* && \
     mkdir -p /scripts

--- a/tools/generate-documentation.sh
+++ b/tools/generate-documentation.sh
@@ -32,7 +32,7 @@ if [[ -n $1 ]]; then
 fi
 
 # Install bookdown
-Rscript -e "install.packages('bookdown')"
+sudo Rscript -e "install.packages('bookdown')"
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../docs"
 

--- a/tools/generate-documentation.sh
+++ b/tools/generate-documentation.sh
@@ -31,6 +31,9 @@ if [[ -n $1 ]]; then
   VERSION=$1
 fi
 
+# Install bookdown
+Rscript -e "install.packages('bookdown')"
+
 cd "$(dirname "${BASH_SOURCE[0]}")/../docs"
 
 ./doxygen/generate-doxygen.sh "${VERSION}"


### PR DESCRIPTION
Addreses https://github.com/rstudio/rstudio-launcher-plugin-sdk/issues/71 and https://github.com/rstudio/rstudio-launcher-plugin-sdk/issues/81

* Updates Boost to 1.83.0 so the SDK compiles on Jammy
* Updates Alpine base image 3.20 since 3.6 was very old
* Uses `pip3` instead of `pip`
* Uses `b2` instead of `bjam` since Boost 1.83.0 _Includes release of [B2 version 4.10.1](https://www.boost.org/tools/build/doc/html/#_version_4_10_1)._