### PR TITLE
Update Boost to 1.83.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,7 @@ project(rlp_sdk_all)
 
 # include globals
 include(CMakeGlobals.txt)
-
 set(CMAKE_CXX_STANDARD 11)
-
 
 string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type)
 if (NOT build_type STREQUAL "debug")
@@ -35,7 +33,7 @@ endif()
 
 # include boost
 if (NOT RLPS_BOOST_REQUESTED_VERSION)
-   set(RLPS_BOOST_REQUESTED_VERSION 1.70.0)
+   set(RLPS_BOOST_REQUESTED_VERSION 1.83.0)
 endif()
 set(Boost_NO_BOOST_CMAKE      OFF)
 set(Boost_USE_STATIC_LIBS     ON)

--- a/dependencies/install-bookdown.sh
+++ b/dependencies/install-bookdown.sh
@@ -50,7 +50,7 @@ if [[ $INSTALL_R -eq 1 ]]; then
   else
     sudo apt-get -y  install apt-transport-https software-properties-common
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
-    sudo add-apt-repository -y 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
+    sudo add-apt-repository -y 'deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/'
     sudo apt update
     sudo apt-get -y install \
       libcurl4-openssl-dev \
@@ -91,7 +91,7 @@ fi
 # Install R libraries
 R -s --vanilla <<EOF
 if (!require("bookdown", quietly = TRUE)) {
-  options(repos = c(CRAN = "https://packagemanager.posit.co/all/__linux__/bionic/latest"))
+  options(repos = c(CRAN = "https://packagemanager.posit.co/all/__linux__/focal/latest"))
   install.packages("bookdown", dependencies = TRUE)
 
   if (!require("bookdown", quietly = TRUE)) {

--- a/dependencies/install-bookdown.sh
+++ b/dependencies/install-bookdown.sh
@@ -52,7 +52,12 @@ if [[ $INSTALL_R -eq 1 ]]; then
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
     sudo add-apt-repository -y 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/'
     sudo apt update
-    sudo apt-get -y install r-base wget
+    sudo apt-get -y install \
+      libcurl4-openssl-dev \
+      libssl-dev \
+      libxml2-dev \
+      r-base \
+      wget
   fi
 fi
 

--- a/dependencies/install-bookdown.sh
+++ b/dependencies/install-bookdown.sh
@@ -84,4 +84,15 @@ if ! [ -d "${PANDOC_INSTALL_DIR}" ]; then
 fi
 
 # Install R libraries
-Rscript -e "if (!require(\"bookdown\", quietly = TRUE)) install.packages(\"bookdown\", dependencies = TRUE)"
+R -s --vanilla <<EOF
+if (!require("bookdown", quietly = TRUE)) {
+  install.packages("bookdown", dependencies = TRUE)
+
+  if (!require("bookdown", quietly = TRUE)) {
+    message("Unable to install bookdown.")
+    warnings()
+    q(status = 1)
+  }
+}
+
+EOF

--- a/dependencies/install-bookdown.sh
+++ b/dependencies/install-bookdown.sh
@@ -86,6 +86,7 @@ fi
 # Install R libraries
 R -s --vanilla <<EOF
 if (!require("bookdown", quietly = TRUE)) {
+  options(repos = c(CRAN = "https://packagemanager.posit.co/all/__linux__/bionic/latest"))
   install.packages("bookdown", dependencies = TRUE)
 
   if (!require("bookdown", quietly = TRUE)) {

--- a/dependencies/install-boost.sh
+++ b/dependencies/install-boost.sh
@@ -29,7 +29,7 @@ set -e
 INSTALL_DIR=$(pwd)
 
 # Variables
-BOOST_VERSION_NUMBER="1.70.0"
+BOOST_VERSION_NUMBER="1.83.0"
 BOOST_VERSION="boost_$(echo "$BOOST_VERSION_NUMBER" | tr "." "_")"
 BOOST_TAR="$BOOST_VERSION.tar.bz2"
 BOOST_BUILD_DIR="boost-build"
@@ -65,7 +65,7 @@ then
    sudo ./bootstrap.sh
 
    # Build boost with bjam
-   sudo ./bjam                      \
+   sudo ./b2                    \
         "$BOOST_BJAM_FLAGS"         \
         variant=release             \
         cxxflags="-fPIC -std=c++11" \

--- a/dependencies/install-boost.sh
+++ b/dependencies/install-boost.sh
@@ -65,7 +65,7 @@ then
    sudo ./bootstrap.sh
 
    # Build boost with bjam
-   sudo ./bjam                    \
+   sudo ./b2                    \
         "$BOOST_BJAM_FLAGS"         \
         variant=release             \
         cxxflags="-fPIC -std=c++11" \

--- a/dependencies/install-boost.sh
+++ b/dependencies/install-boost.sh
@@ -65,7 +65,7 @@ then
    sudo ./bootstrap.sh
 
    # Build boost with bjam
-   sudo ./b2                    \
+   sudo ./bjam                    \
         "$BOOST_BJAM_FLAGS"         \
         variant=release             \
         cxxflags="-fPIC -std=c++11" \

--- a/docker/jenkins/Dockerfile.packaging
+++ b/docker/jenkins/Dockerfile.packaging
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 
 ARG AWS_REGION=us-east-1
 

--- a/docker/jenkins/Dockerfile.versioning
+++ b/docker/jenkins/Dockerfile.versioning
@@ -9,7 +9,7 @@ RUN apk -v --update add \
         mailcap \
         sudo \
         && \
-    pip install --upgrade awscli s3cmd python-magic && \
+    pip3 install --upgrade awscli s3cmd python-magic && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/* && \
     mkdir -p /scripts

--- a/docker/jenkins/Dockerfile.versioning
+++ b/docker/jenkins/Dockerfile.versioning
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:latest
 RUN apk -v --update add \
         bash \
         python \
@@ -9,7 +9,7 @@ RUN apk -v --update add \
         mailcap \
         sudo \
         && \
-    pip install --upgrade awscli==0.4.1 s3cmd python-magic && \
+    pip install --upgrade awscli s3cmd python-magic && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/* && \
     mkdir -p /scripts

--- a/docker/jenkins/Dockerfile.versioning
+++ b/docker/jenkins/Dockerfile.versioning
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.20
 RUN apk -v --update add \
         bash \
         python \

--- a/docker/jenkins/Dockerfile.versioning
+++ b/docker/jenkins/Dockerfile.versioning
@@ -1,17 +1,14 @@
 FROM alpine:3.20
-RUN apk -v --update add \
+RUN apk -v --update --no-cache add \
         bash \
         python3 \
-        py-pip \
         git \
         groff \
         less \
         mailcap \
         sudo \
         && \
-    pip3 install --upgrade awscli s3cmd python-magic && \
-    apk -v --purge del py-pip && \
-    rm /var/cache/apk/* && \
+    apk add --no-cache aws-cli s3cmd py3-magic && \
     mkdir -p /scripts
 
 ARG JENKINS_GID=999

--- a/docker/jenkins/Dockerfile.versioning
+++ b/docker/jenkins/Dockerfile.versioning
@@ -1,7 +1,7 @@
 FROM alpine:3.20
 RUN apk -v --update add \
         bash \
-        python \
+        python3 \
         py-pip \
         git \
         groff \

--- a/docker/jenkins/Dockerfile.versioning
+++ b/docker/jenkins/Dockerfile.versioning
@@ -9,7 +9,7 @@ RUN apk -v --update add \
         mailcap \
         sudo \
         && \
-    pip install --upgrade awscli s3cmd python-magic && \
+    pip install --upgrade awscli==0.4.1 s3cmd python-magic && \
     apk -v --purge del py-pip && \
     rm /var/cache/apk/* && \
     mkdir -p /scripts


### PR DESCRIPTION
Addresses #71 and #81

Supersedes #80

- **Update boost to 1.83.0**
- **Test CI fix**
- **Update install-boost.sh**
- **Test for CI**
- **Use alpine 3.20**
- **Install python3**
- **Try pip3 for CI**
- **Fixed**
- **Test to use b2 instead of bjam**
- **Fail container build if bookdown not installed**
- **Use Public Package Manager for R packages**
- **Add libs required to build source R packages**
- **Move packaging image to Ubuntu 20.04**
