### PR TITLE
Switch from posit-jenkins credentials to the new posit-jenkins-rstudi…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,7 +157,7 @@ try {
             prepareWorkspace()
             def image_tag = "${current_container.os}-${current_container.arch}-${params.RLP_SDK_VERSION_MAJOR}.${params.RLP_SDK_VERSION_MINOR}"
             retry(1) {
-              withCredentials([usernameColonPassword(credentialsId: 'posit-jenkins', variable: "github_login")]) {
+              withCredentials([usernameColonPassword(credentialsId: 'posit-jenkins-rstudio', variable: "github_login")]) {
                 def github_args = '--build-arg GITHUB_LOGIN=${github_login}'
                 container = pullBuildPush(image_name: 'jenkins/rlp-sdk', dockerfile: "docker/jenkins/Dockerfile.${current_container.os}-${current_container.arch}", image_tag: image_tag, build_args: github_args + " " + jenkins_user_build_args())
               }


### PR DESCRIPTION
…o credentials.

We are in the process of deprecating the old `posit-jenkins` credentials.  It is replaced by `posit-jenkins-rstudio`.  The credentials have the exact same permissions, and have been in use for a few weeks in a couple of locations, and since monday across all the jenkins jobs on the jenkins server.  

Changing the references to the credentials in all the various Jenkinsfiles in across many repos in the company is the next step!

This PR accomplishes that goal for the `rstudio-launcher-plugin-sdk` repo.


Connected to issue https://github.com/rstudio/cloudops/issues/543