### PR TITLE
Add workaround for centos 8 sudo issue

### DIFF
--- a/docker/jenkins/Dockerfile.centos8-x86_64
+++ b/docker/jenkins/Dockerfile.centos8-x86_64
@@ -13,3 +13,6 @@ RUN /tmp/clean-gid-and-uid.sh $JENKINS_GID $JENKINS_UID
 RUN groupadd -g $JENKINS_GID jenkins && \
     useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
     echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# Workaround for sudo issues when running in CI: https://github.com/linux-pam/linux-pam/issues/876 and Launcher issue 1149
+RUN chmod u+r /etc/shadow


### PR DESCRIPTION
* Issue is a combination of Ubuntu Noble hosts, Docker containers, and specific versions of linux-pam.
* Without this workaround sudo in the build/test container fails.
* Main Launcher repo had the same issue and has the same issue applied to it.